### PR TITLE
Use qualified elements in schema #117

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Version 2.0 RC2 was approved by the Global Technical Committee on August 15, 201
 Themes of this release:
 
 * Clarification about single-byte character sets
-* Improvement of the XML schema, including support for XIinclude
+* Improvement of the XML schema, including support for XInclude
 
 ### Version 2.0 Release Candidate 1
 

--- a/v2-0-RC3/doc/00Title.md
+++ b/v2-0-RC3/doc/00Title.md
@@ -5,7 +5,7 @@ FIX Simple Binary Encoding
 
 ## Technical Specification
 
-Version 2.0 Release Candidate 2  
+Version 2.0 Release Candidate 3  
 
 **THIS DOCUMENT IS A RELEASE CANDIDATE FOR A PROPOSED FIX TECHNICAL
 STANDARD. A RELEASE CANDIDATE HAS BEEN APPROVED BY THE GLOBAL TECHNICAL

--- a/v2-0-RC3/doc/04MessageSchema.md
+++ b/v2-0-RC3/doc/04MessageSchema.md
@@ -3,7 +3,7 @@
 
 XML schema for SBE message schemas
 ---------
-See [SBE XSD](../resources/sbe-2.0rc2.xsd) for the normative XML Schema Definition (XSD) for SBE.
+See [SBE XSD](../resources/sbe-2.0rc3.xsd) for the normative XML Schema Definition (XSD) for SBE.
 
 The SBE schema is defined with W3C XML Schema Definition Language (XSD) version 1.0. (XSD version 1.1 was standardized.
 However, since it is not supported by all XML processors, the SBE XSD is constrained to features of version 1.0.)
@@ -367,7 +367,7 @@ The `name` attribute of the `<choice>` uniquely identifies it.
 | sinceVersion         | Documents the version of a schema in which a choice was added                                                    | nonNegativeInteger | default = 0 |                                                                  |
 | deprecated           | Documents the version of a schema in which a choice was deprecated. It should no longer be used in new messages. | nonnegativeInteger | optional    | Must be less than or equal to the version of the message schema. |
 
-#### `<choice>` element content
+#### `< choice >` element content
 
 The element is required to carry a value, which is an unsigned integer
 representing a zero-based index to a bit within a bitset. Zero is the

--- a/v2-0-RC3/doc/07Examples.md
+++ b/v2-0-RC3/doc/07Examples.md
@@ -9,7 +9,7 @@ Not all FIX enumeration values are listed in the samples.
 ## SBE Message Schema
 ```xml
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2017/sbe" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" package="Examples" id="91" version="0" byteOrder="littleEndian" xsi:schemaLocation="http://fixprotocol.io/2017/sbe sbe-2.0rc2.xsd">
+<messageSchema xmlns="http://fixprotocol.io/2017/sbe" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" package="Examples" id="91" version="0" byteOrder="littleEndian" xsi:schemaLocation="http://fixprotocol.io/2017/sbe sbe-2.0rc3.xsd">
 	<types>
 		<type name="date" primitiveType="uint16"/>
 		<type name="enumEncoding" primitiveType="char"/>
@@ -98,12 +98,12 @@ Not all FIX enumeration values are listed in the samples.
 		</enum>
 	</types>
 	<messages>
-		<sbe:message name="BusinessMessageReject" id="97" blockLength="9" semanticType="j">
+		<message name="BusinessMessageReject" id="97" blockLength="9" semanticType="j">
 			<field name="BusinesRejectRefId" id="379" type="idString" offset="0" semanticType="String"/>
 			<field name="BusinessRejectReason" id="380" type="businessRejectReasonEnum" offset="8" semanticType="int"/>
 			<data name="Text" id="58" type="DATA" semanticType="data"/>
-		</sbe:message>
-		<sbe:message name="ExecutionReport" id="98" blockLength="42" semanticType="8">
+		</message>
+		<message name="ExecutionReport" id="98" blockLength="42" semanticType="8">
 			<field name="OrderID" id="37" type="idString" offset="0" semanticType="String"/>
 			<field name="ExecID" id="17" type="idString" offset="8" semanticType="String"/>
 			<field name="ExecType" id="150" type="execTypeEnum" offset="16" semanticType="char"/>
@@ -118,8 +118,8 @@ Not all FIX enumeration values are listed in the samples.
 				<field name="FillPx" id="1364" type="decimalEncoding" offset="0" semanticType="Price"/>
 				<field name="FillQty" id="1365" type="qtyEncoding" offset="8" semanticType="Qty"/>
 			</group>
-		</sbe:message>
-		<sbe:message name="NewOrderSingle" id="99" blockLength="54" semanticType="D">
+		</message>
+		<message name="NewOrderSingle" id="99" blockLength="54" semanticType="D">
 			<field name="ClOrdId" id="11" type="idString" offset="0" semanticType="String"/>
 			<field name="Account" id="1" type="idString" offset="8" semanticType="String"/>
 			<field name="Symbol" id="55" type="idString" offset="16" semanticType="String"/>
@@ -129,9 +129,9 @@ Not all FIX enumeration values are listed in the samples.
 			<field name="OrdType" id="40" type="ordTypeEnum" offset="37" semanticType="char"/>
 			<field name="Price" id="44" type="decimalEncoding" offset="38" semanticType="Price" presence="optional"/>
 			<field name="StopPx" id="99" type="decimalEncoding" offset="46" semanticType="Price" presence="optional"/>
-		</sbe:message>
+		</message>
 	</messages>
-</sbe:messageSchema>
+</messageSchema>
 ```
 
 

--- a/v2-0-RC3/resources/xml/examples.xml
+++ b/v2-0-RC3/resources/xml/examples.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2017/sbe" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xi="http://www.w3.org/2001/XInclude" package="examples" id="91" version="0" byteOrder="littleEndian" xsi:schemaLocation="http://fixprotocol.io/2017/sbe ../xsd/sbe-2.0rc2.xsd">
+<messageSchema xmlns="http://fixprotocol.io/2017/sbe" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xi="http://www.w3.org/2001/XInclude" package="examples" id="91" version="0" byteOrder="littleEndian" xsi:schemaLocation="http://fixprotocol.io/2017/sbe ../xsd/sbe-2.0rc3.xsd">
 	<!-- include commonly used types -->
-	<xi:include href="types-include.xml" parse="xml"/>
+	<xi:include href="types-include.xml"/>
 	<types>
 		<type name="date" primitiveType="uint16"/>
 		<type name="enumEncoding" primitiveType="char"/>
@@ -84,7 +84,7 @@
 		</enum>
 	</types>
 	<messages>
-		<sbe:message name="ExecutionReport" id="98" blockLength="42" semanticType="8">
+		<message name="ExecutionReport" id="98" blockLength="42" semanticType="8">
 			<field name="OrderID" id="37" type="idString" offset="0" semanticType="String"/>
 			<field name="ExecID" id="17" type="idString" offset="8" semanticType="String"/>
 			<field name="ExecType" id="150" type="execTypeEnum" offset="16" semanticType="char"/>
@@ -99,8 +99,8 @@
 				<field name="FillPx" id="1364" type="decimalEncoding" offset="0" semanticType="Price"/>
 				<field name="FillQty" id="1365" type="qtyEncoding" offset="8" semanticType="Qty"/>
 			</group>
-		</sbe:message>
-		<sbe:message name="NewOrderSingle" id="99" blockLength="54" semanticType="D">
+		</message>
+		<message name="NewOrderSingle" id="99" blockLength="54" semanticType="D">
 			<field name="ClOrdId" id="11" type="idString" offset="0" semanticType="String"/>
 			<field name="Account" id="1" type="idString" offset="8" semanticType="String"/>
 			<field name="Symbol" id="55" type="idString" offset="16" semanticType="String"/>
@@ -110,8 +110,8 @@
 			<field name="OrdType" id="40" type="ordTypeEnum" offset="37" semanticType="char"/>
 			<field name="Price" id="44" type="decimalEncoding" offset="38" semanticType="Price" presence="optional"/>
 			<field name="StopPx" id="99" type="decimalEncoding" offset="46" semanticType="Price" presence="optional"/>
-		</sbe:message>
+		</message>
 	</messages>
 	<!-- include commonly used messages -->
-	<xi:include href="messages-include.xml" parse="xml"/>
-</sbe:messageSchema>
+	<xi:include href="messages-include.xml"/>
+</messageSchema>

--- a/v2-0-RC3/resources/xml/messages-include.xml
+++ b/v2-0-RC3/resources/xml/messages-include.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<messages xmlns:sbe="http://fixprotocol.io/2017/sbe" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" description="Commonly used messsages may be imported into multiple message schemas using XInclude">
-	<sbe:message name="BusinessMessageReject" id="97" blockLength="9" semanticType="j">
+<messages xmlns="http://fixprotocol.io/2017/sbe" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://fixprotocol.io/2017/sbe ../xsd/sbe-2.0rc3.xsd"
+description="Commonly used messsages may be imported into multiple message schemas using XInclude">
+	<message name="BusinessMessageReject" id="97" blockLength="9" semanticType="j">
 		<field name="BusinesRejectRefId" id="379" type="idString" offset="0" semanticType="String"/>
 		<field name="BusinessRejectReason" id="380" type="businessRejectReasonEnum" offset="8" semanticType="int"/>
 		<data name="Text" id="58" type="DATA" semanticType="data"/>
-	</sbe:message>
+	</message>
 </messages>

--- a/v2-0-RC3/resources/xml/types-include.xml
+++ b/v2-0-RC3/resources/xml/types-include.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<types xmlns:sbe="http://fixprotocol.io/2017/sbe" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+<types xmlns="http://fixprotocol.io/2017/sbe" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://fixprotocol.io/2017/sbe ../xsd/sbe-2.0rc3.xsd"
 description="Commonly used types may be imported into multiple message schemas using XInclude">
 	<composite name="MONTH_YEAR">
 		<type name="year" primitiveType="uint16"/>

--- a/v2-0-RC3/resources/xsd/sbe-2.0rc3.xsd
+++ b/v2-0-RC3/resources/xsd/sbe-2.0rc3.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns:sbe="http://fixprotocol.io/2017/sbe" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://fixprotocol.io/2017/sbe" elementFormDefault="unqualified" version="2.0RC2">
+<xs:schema xmlns:sbe="http://fixprotocol.io/2017/sbe" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://fixprotocol.io/2017/sbe" elementFormDefault="qualified" version="2.0RC3">
 	<xs:annotation>
 		<xs:documentation>
 			Message schema for FIX Simple Binary Encoding
@@ -20,46 +20,8 @@
 		</xs:annotation>
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="types" maxOccurs="unbounded">
-					<xs:annotation>
-						<xs:documentation>
-							More than one set of types may be provided.
-							Names must be unique across all encoding
-							types.
-							Encoding types may appear in any order.
-						</xs:documentation>
-					</xs:annotation>
-					<xs:complexType>
-						<xs:choice maxOccurs="unbounded">
-							<xs:element name="type" type="sbe:simpleDataType"/>
-							<xs:element name="composite" type="sbe:compositeDataType"/>
-							<xs:element name="enum" type="sbe:enumType"/>
-							<xs:element name="set" type="sbe:setType"/>
-						</xs:choice>
-						<xs:attribute name="description" type="xs:string"/>
-						<xs:attribute name="package" type="xs:string">
-							<xs:annotation>
-								<xs:documentation>Overrides the messageSchema package</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
-						<xs:attribute ref="xml:base"/>
-					</xs:complexType>
-				</xs:element>
-				<xs:element name="messages" maxOccurs="unbounded">
-					<xs:complexType>
-						<xs:sequence>
-							<xs:element ref="sbe:message" maxOccurs="unbounded"/>
-						</xs:sequence>
-						<xs:attribute name="description" type="xs:string"/>
-						<xs:attribute name="package" type="xs:string">
-							<xs:annotation>
-								<xs:documentation>Overrides the messageSchema package</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
-						<!-- required to support XIinclude -->
-						<xs:attribute ref="xml:base"/>
-					</xs:complexType>
-				</xs:element>
+				<xs:element ref="sbe:types" maxOccurs="unbounded"/>
+				<xs:element ref="sbe:messages" maxOccurs="unbounded"/>
 			</xs:sequence>
 			<xs:attribute name="package" type="xs:string"/>
 			<xs:attribute name="id" type="xs:unsignedShort">
@@ -102,12 +64,52 @@
 			</xs:attribute>
 		</xs:complexType>
 	</xs:element>
-	<xs:element name="message" type="sbe:blockType">
+	<xs:element name="messages">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="message" type="sbe:blockType" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>
+							A message type, also known as a message template
+						</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:sequence>
+			<xs:attribute name="description" type="xs:string"/>
+			<xs:attribute name="package" type="xs:string">
+				<xs:annotation>
+					<xs:documentation>Overrides the messageSchema package</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<!-- required to support XInclude -->
+			<xs:attribute ref="xml:base"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="types">
 		<xs:annotation>
 			<xs:documentation>
-				A message type, also known as a message template
+				More than one set of types may be provided.
+				Names must be unique across all encoding
+				types.
+				Encoding types may appear in any order.
 			</xs:documentation>
 		</xs:annotation>
+		<xs:complexType>
+			<xs:choice maxOccurs="unbounded">
+				<xs:element name="type" type="sbe:simpleDataType"/>
+				<xs:element name="composite" type="sbe:compositeDataType"/>
+				<xs:element name="enum" type="sbe:enumType"/>
+				<xs:element name="set" type="sbe:setType"/>
+			</xs:choice>
+			<xs:attribute name="description" type="xs:string"/>
+			<xs:attribute name="package" type="xs:string">
+				<xs:annotation>
+					<xs:documentation>Overrides the messageSchema package</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<!-- required to support XInclude -->
+			<xs:attribute ref="xml:base"/>
+		</xs:complexType>
 	</xs:element>
 	<!-- Complex types -->
 	<xs:complexType name="blockType">


### PR DESCRIPTION
Patch request for issue #117:
- make elementFormDefault="qualified"
- make 'messageSchema', 'types', and 'messages' top elements (to allow partial included XML's validation)
- move 'message' inside 'messages' (to disallow it to be top-element in XML)
- fix XML sample (namespaces, remove redundant attributes)
