### PR TITLE
Fixes some typos in schema extension mechanism

### DIFF
--- a/v2-0-RC3/doc/05SchemaExtensionMechanism.md
+++ b/v2-0-RC3/doc/05SchemaExtensionMechanism.md
@@ -106,7 +106,7 @@ encoding.
 
 Message headers and repeating group dimensions carry a count of the number of repeating groups and a count of variable-length data fields on the wire. This supports a walk by a decoder of all the elements of a message, even when the decoder was built with an older version of a schema. As for added fixed-length fields, new repeating groups cannot be interpreted by the decoder, but it still can process the ones it knows, and it can correctly reach the end of a message.
 
-## Comaptibility strategy
+## Compatibility strategy
 
 *This suggested strategy is non-normative.*
 
@@ -153,7 +153,7 @@ Second version - a new message is added
     <field name="Field1" id="1" type="int8" semanticType="int"/>
 </message>
 
-<!-- New message added in this version-->
+<!-- New message added in this version -->
 <message name="FIX Binary Message2" id="2" blockLength="4"
     sinceVersion="1">
     <field name="Field2" id="2" type="int16" semanticType="int"/>


### PR DESCRIPTION
Didn't address another thing, which I found confusing. In the "Message schema extension example", three versions are discussed, but only 2 version numbers are used. It could be more clear to use a different word if "a new message is added" is intentionally mutating an existing version. For example, instead of saying "Second version - a new message is added", you could say "First change - a new message is added to an existing version". This reduces the pressure on the word "version" used for different reasons in the same section. If on the other hand it was a typo to not increment the version, we should fix that :D