### PR TITLE
Clarifies text in schema extension example

### DIFF
--- a/v2-0-RC3/doc/05SchemaExtensionMechanism.md
+++ b/v2-0-RC3/doc/05SchemaExtensionMechanism.md
@@ -201,9 +201,5 @@ This update changes a message from the initial schema and adds a type.
 </messageSchema>
 ```
 
-Notice field addition effects only the version of the field: We don't update
-`sinceVersion` on a message when we add a field to it.
-
-*Note:* `sinceVersion` is not required, and has no default interpretation. In
-other words, "FIX Binary Message1" cannot be assumed as since version zero. To
-clarify this, consider adding `sinceVersion` on initial schema elements.
+Notice adding fields does not effect `sinceVersion` on the message that
+contains them.

--- a/v2-0-RC3/doc/05SchemaExtensionMechanism.md
+++ b/v2-0-RC3/doc/05SchemaExtensionMechanism.md
@@ -122,13 +122,18 @@ If the *received version is less than the decoder's version* (that is, the produ
 
 ## Message schema extension example
 
-Initial version of a message schema
+The following example walks through changes to a schema to reinforce how schema
+versioning works.
 
+### Initial schema
+
+Here's the initial example schema:
 ```xml
 <messageSchema package="FIXBinaryTest" byteOrder="littleEndian">
-    <types>
-        <type name="int8" primitiveType="int8"/>
-    </types>
+
+<types>
+    <type name="int8" primitiveType="int8"/>
+</types>
 
 <message name="FIX Binary Message1" id="1" blockLength="4">
     <field name="Field1" id="1" type="int8" semanticType="int"/>
@@ -137,7 +142,13 @@ Initial version of a message schema
 </messageSchema>
 ```
 
-Second version - a new message is added
+### Adding elements to the schema
+
+Below adds new elements to the schema. Upon any update we must increment the
+`version` attribute. When there is no `version` attribute, the version is zero.
+Hence, our new version is one. This version applies to all change. 
+
+This update chooses to document updates with the `sinceVersion` attribute.
 
 ```xml
 <messageSchema package="FIXBinaryTest" byteOrder="littleEndian"
@@ -161,7 +172,9 @@ Second version - a new message is added
 </messageSchema>
 ```
 
-Third version - a field is added
+### Adding a field to a message
+
+This update changes a message from the initial schema and adds a type.
 
 ```xml
 <messageSchema package="FIXBinaryTest" byteOrder="littleEndian"
@@ -187,3 +200,10 @@ Third version - a field is added
 </message>
 </messageSchema>
 ```
+
+Notice field addition effects only the version of the field: We don't update
+`sinceVersion` on a message when we add a field to it.
+
+*Note:* `sinceVersion` is not required, and has no default interpretation. In
+other words, "FIX Binary Message1" cannot be assumed as since version zero. To
+clarify this, consider adding `sinceVersion` on initial schema elements.


### PR DESCRIPTION
While correct, the schema extension example could be misinterpreted due
to vocabulary used. For example, a new reader who missed the implicit
zero based versioning, could misunderstand how version 1 appeared in
updates.

This change walks through the thinking behind the example, so that
readers have less cognitive break even if they misread the spec.